### PR TITLE
Fix looping audio when InstaKillPlayer is false

### DIFF
--- a/KidnapperFoxSettings/KidnapperFoxSettings.csproj
+++ b/KidnapperFoxSettings/KidnapperFoxSettings.csproj
@@ -39,7 +39,7 @@
   </ItemGroup>
   
   <PropertyGroup>
-    <PluginsFolder>D:\SteamLibrary\steamapps\common\Lethal Company\BepInEx\plugins</PluginsFolder>
+    <PluginsFolder>C:\Users\em\AppData\Roaming\com.kesomannen.gale\lethal-company\profiles\foxtest\BepInEx\plugins\Zehs-KidnapperFoxSettings</PluginsFolder>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <GenerateDocumentationFile>False</GenerateDocumentationFile>
 	</PropertyGroup>


### PR DESCRIPTION
When InstaKillPlayer is set to false, the fox's dragging audio loops indefinitely after damaging the player. This change stops the audio sources when the fox is stunned and plays the bite sound to indicate damage was dealt.