### PR TITLE
Fix looping audio when InstaKillPlayer is false

### DIFF
--- a/KidnapperFoxSettings/Patches/BushWolfEnemyPatch.cs
+++ b/KidnapperFoxSettings/Patches/BushWolfEnemyPatch.cs
@@ -53,6 +53,24 @@ internal class BushWolfEnemyPatch
                 {
                     localPlayerScript.DamagePlayer(damage, hasDamageSFX: true, callRPC: true, causeOfDeath: CauseOfDeath.Mauling, deathAnimation: 8);
                     __instance.SetEnemyStunned(true, Plugin.ConfigManager.DamageInterval.Value, localPlayerScript);
+
+                    if (__instance.creatureVoice != null && __instance.creatureVoice.isPlaying)
+                    {
+                        __instance.creatureVoice.Stop();
+                    }
+                    if (__instance.growlAudio != null && __instance.growlAudio.isPlaying)
+                    {
+                        __instance.growlAudio.Stop();
+                    }
+                    if (__instance.tongueAudio != null && __instance.tongueAudio.isPlaying)
+                    {
+                        __instance.tongueAudio.Stop();
+                    }
+
+                    if (__instance.killSFX != null)
+                    {
+                        __instance.creatureSFX.PlayOneShot(__instance.killSFX);
+                    }
                 }
             }
         }


### PR DESCRIPTION
When InstaKillPlayer is set to false, the fox's dragging audio loops indefinitely after damaging the player. This change stops the audio sources when the fox is stunned and plays the bite sound to indicate damage was dealt.